### PR TITLE
feat: add ToggleCommunityProfile component

### DIFF
--- a/src/pages/Events.jsx
+++ b/src/pages/Events.jsx
@@ -30,15 +30,7 @@ export default function Events() {
             Encontre eventos de tecnologia em todo o Nordeste, presencial e online. Filtre por tipo e data.
           </Typography>
         </Typography>
-        {/* <Typography maxWidth='xl'>
-          <main className='px-6 py-10 max-w-7xl mx-auto'>
-            <h1 className='text-3xl font-semibold mb-2'>Eventos</h1>
-            <p className='text-gray-500 mb-6'>Encontre eventos de tecnologia em todo o Nordeste, presencial e online. Filtre por tipo e data.</p>
-          </main>
-        </Typography> */}
-
         <Searchbar />
-
         <Box sx={{ display: 'flex', gap: 2 }}>
           <Box>
             <EventTypeSelector />

--- a/src/shared/components/ToggleCommunityProfile/index.jsx
+++ b/src/shared/components/ToggleCommunityProfile/index.jsx
@@ -1,0 +1,58 @@
+import { useState } from 'react'
+
+import Box from '@mui/material/Box'
+import ToggleButton from '@mui/material/ToggleButton'
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup'
+
+export default function ToogleCommunityProfile() {
+  const [eventType, setEventType] = useState('eventos')
+
+  const options = ['eventos', 'sobre']
+
+  return (
+    <Box>
+      <Box
+        sx={{
+          p: '6px',
+          my: '1rem',
+          borderRadius: '8px',
+          display: 'inline-flex',
+          backgroundColor: '#f4f6f8'
+        }}>
+        <ToggleButtonGroup
+          value={eventType}
+          exclusive
+          onChange={(_, val) => val && setEventType(val)}
+          sx={{ gap: 1 }}>
+          {options.map((type) => (
+            <ToggleButton
+              key={type}
+              value={type}
+              sx={{
+                '&': {
+                  py: 1,
+                  px: 3,
+                  fontSize: '12px',
+                  border: 'none',
+                  textWrap: 'nowrap',
+                  borderRadius: '8px',
+                  textTransform: 'none',
+                  fontWeight: eventType === type ? 700 : 500,
+                  color: eventType === type ? '#111827' : '#6b7280',
+                  backgroundColor: eventType === type ? '#fff' : 'transparent'
+                },
+                '&:hover': {
+                  backgroundColor: eventType === type ? '#fff' : '#e5e7eb'
+                },
+                '&.Mui-selected, &.Mui-selected:hover': {
+                  backgroundColor: '#fff'
+                }
+              }}>
+              {type.charAt(0).toUpperCase() + type.slice(1)}
+            </ToggleButton>
+          ))}
+        </ToggleButtonGroup>
+      </Box>
+    </Box>
+  )
+}


### PR DESCRIPTION
🎛️ Criado componente ToggleCommunityProfile com botões para alternar entre "Eventos" e "Sobre".

🔤 Os valores são exibidos com a primeira letra maiúscula, mas a lógica interna de seleção é case-insensitive para evitar erros de comparação.